### PR TITLE
Adding PSR-2 code formatting checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
 		"psr/log": "1.0.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "3.7.*"
+		"phpunit/phpunit": "3.7.*",
+		"phpro/grumphp": "^0.9.1",
+		"squizlabs/php_codesniffer": "^2.6"
 	},
         "autoload": {
             "psr-4": {

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,0 +1,11 @@
+parameters:
+    git_dir: .
+    bin_dir: vendor/bin
+    tasks:
+      phpcs:
+        standard: 'PSR2'
+        show_warnings: false
+        tab_width: ~
+        ignore_patterns: ['vendor/*']
+        sniffs: []
+        triggered_by: [php]


### PR DESCRIPTION
Adding a PR as a suggestion to seriusly embrace PSR-2 / PHP-Fig standards 

At the moment the PR does not include PHPCSfixer as a step in Grumphp. 
Suggestion: 
- evaluate PSR2 or the Symfony standard to be embraced as part of phplist
- discuss the need to force the standard compliance with Grumphp

Once the above is discussed I can modify the PR if necessary. To see the PHPCS/Grumphp report do the following

```
git clone https://github.com/bizmate/phpList.git
composer install
vendor/bin/grumphp run
```

Also a quick comment on something unrelated but still:
 - why is the composer.lock file ignored? This file should be installed to avoid having composer to workout dependencies versions everytime.
 - why is the phpunit.xml ignored. It would be nice to know how unit tests are running and the it does not look like the .dist file has any real configuration.