### PR TITLE
[TASK] Drop support for PHP < 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	},
 	"minimum-stability": "dev",
 	"require": {
-		"php": ">=5.4.0",
+		"php": ">=5.6.0,<=7.1.99"
 		"symfony/dependency-injection": "~2.6",
         "symfony/yaml": "~2.6",
         "symfony/config": "~2.6",

--- a/core/helper/Session.php
+++ b/core/helper/Session.php
@@ -45,11 +45,9 @@ class Session
     }
 }
 
-//PHP >= 5.4.0 can use a SessionHandlerInerface implementation
-class MySQLSessionHandler /*implements \SessionHandlerInterface*/
+class MySQLSessionHandler implements \SessionHandlerInterface
 {
     /**
-     * PHP >= 5.4.0<br/>
      * Close the session
      * @link http://php.net/manual/en/sessionhandlerinterafce.close.php
      * @return bool <p>
@@ -63,7 +61,6 @@ class MySQLSessionHandler /*implements \SessionHandlerInterface*/
     }
 
     /**
-     * PHP >= 5.4.0<br/>
      * Destroy a session
      * @link http://php.net/manual/en/sessionhandlerinterafce.destroy.php
      * @param int $session_id The session ID being destroyed.
@@ -86,7 +83,6 @@ class MySQLSessionHandler /*implements \SessionHandlerInterface*/
     }
 
     /**
-     * PHP >= 5.4.0<br/>
      * Cleanup old sessions
      * @link http://php.net/manual/en/sessionhandlerinterafce.gc.php
      * @param int $maxlifetime <p>
@@ -113,7 +109,6 @@ class MySQLSessionHandler /*implements \SessionHandlerInterface*/
     }
 
     /**
-     * PHP >= 5.4.0<br/>
      * Initialize session
      * @link http://php.net/manual/en/sessionhandlerinterafce.open.php
      * @param string $save_path The path where to store/retrieve the session.
@@ -129,7 +124,6 @@ class MySQLSessionHandler /*implements \SessionHandlerInterface*/
     }
 
     /**
-     * PHP >= 5.4.0<br/>
      * Read session data
      * @link http://php.net/manual/en/sessionhandlerinterafce.read.php
      * @param string $session_id The session id to read data for.
@@ -153,7 +147,6 @@ class MySQLSessionHandler /*implements \SessionHandlerInterface*/
     }
 
     /**
-     * PHP >= 5.4.0<br/>
      * Write session data
      * @link http://php.net/manual/en/sessionhandlerinterafce.write.php
      * @param string $session_id The session id.

--- a/core/phpList.php
+++ b/core/phpList.php
@@ -169,9 +169,8 @@ class phpList
 
     protected function configPhpVer()
     {
-        //TODO: we probably will need >5.3
-        if (version_compare(PHP_VERSION, '5.1.2', '<') && $this->config->get('WARN_ABOUT_PHP_SETTINGS')) {
-            throw new \Exception($this->lan->get('phpList requires PHP version 5.1.2 or higher'));
+        if (version_compare(PHP_VERSION, '5.6.0', '<') && $this->config->get('WARN_ABOUT_PHP_SETTINGS')) {
+            throw new \Exception($this->lan->get('phpList requires PHP version 5.6.0 or higher'));
         }
     }
 


### PR DESCRIPTION
PHP 5.4 and PHP 5.5 have reached their end of life and thus are not
supported anymore (not even with security updates). So PHPList will
not support it anymore, either.