### PR TITLE
[BUGFIX] Load an existing config file in the unit tests

### DIFF
--- a/core/tests/AdminTest.php
+++ b/core/tests/AdminTest.php
@@ -29,6 +29,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         // Load the service config file, which is in YAML format
         $loader->load('../services.yml');
         // Get objects from container
+        $this->container->setParameter('config.configfile', __DIR__ . '/../../config.ini.dist');
         $this->config = $this->container->get('Config');
 
         $this->admin = $this->container->get('Admin');

--- a/core/tests/ListManagerTest.php
+++ b/core/tests/ListManagerTest.php
@@ -27,7 +27,7 @@ class ListManagerTest extends \PHPUnit_Framework_TestCase
         // Load the service config file, which is in YAML format
         $loader->load('../services.yml');
         // Set necessary config class parameter
-        $this->container->setParameter('config.configfile', '/var/www/pl4/config.ini');
+        $this->container->setParameter('config.configfile', __DIR__ . '/../../config.ini.dist');
         // Get objects from container
         $this->scrEntity = $this->container->get('SubscriberEntity');
         $this->listManager = $this->container->get('ListManager');

--- a/core/tests/ListModelTest.php
+++ b/core/tests/ListModelTest.php
@@ -26,7 +26,7 @@ class ListModelTest extends \PHPUnit_Framework_TestCase
         // Load the service config file, which is in YAML format
         $loader->load('../services.yml');
         // Set necessary config class parameter
-        $this->container->setParameter('config.configfile', '/var/www/pl4/config.ini');
+        $this->container->setParameter('config.configfile', __DIR__ . '/../../config.ini.dist');
         // Get objects from container
         $this->listModel = $this->container->get('ListModel');
     }

--- a/core/tests/PassTest.php
+++ b/core/tests/PassTest.php
@@ -20,6 +20,7 @@ class PassTest extends \PHPUnit_Framework_TestCase
         $loader = new YamlFileLoader($this->container, new FileLocator(__DIR__));
         // Load the service config file, which is in YAML format
         $loader->load('../services.yml');
+        $this->container->setParameter('config.configfile', __DIR__ . '/../../config.ini.dist');
         // Get objects from container
         $this->pass = $this->container->get('Pass');
         // Set default pwd for testing

--- a/core/tests/ServicesTest.php
+++ b/core/tests/ServicesTest.php
@@ -27,20 +27,15 @@ class ServicesTest extends \PHPUnit_Framework_TestCase
         $loader = new YamlFileLoader($this->container, new FileLocator(__DIR__));
         // Load the service config file, which is in YAML format
         $loader->load('../services.yml');
+        $this->container->setParameter('config.configfile', __DIR__ . '/../../config.ini.dist');
     }
 
     public function testConfigService()
     {
-        // Set service parameters
-        $this->container->setParameter('config.configfile', '/var/www/pl4/config.ini');
-
         $config = $this->container->get('Config');
     }
     public function testPhplistService()
     {
-        // Set service parameters
-        $this->container->setParameter('config.configfile', '/var/www/pl4/config.ini');
-        
         $config = $this->container->get('phpList');
     }
 }

--- a/core/tests/SubscriberManagerTest.php
+++ b/core/tests/SubscriberManagerTest.php
@@ -45,6 +45,7 @@ class SubscriberTest extends \PHPUnit_Framework_TestCase
         $loader = new YamlFileLoader($this->container, new FileLocator(__DIR__));
         // Load the service config file, which is in YAML format
         $loader->load('../services.yml');
+        $this->container->setParameter('config.configfile', __DIR__ . '/../../config.ini.dist');
         $this->subscriberManager = $this->container->get('SubscriberManager');
     }
 

--- a/core/tests/SubscriberModelTest.php
+++ b/core/tests/SubscriberModelTest.php
@@ -29,7 +29,7 @@ class SubscriberModelTest extends \PHPUnit_Framework_TestCase
         $this->plainPass = 'easypassword';
 
         // Instantiate config object
-        $this->configFile = dirname(__FILE__) . '/../../config.ini';
+        $this->configFile = __DIR__ . '/../../config.ini.dist';
         $this->config = new Config($this->configFile);
 
         // Instantiate remaining classes

--- a/core/tests/phpunit-bootstrap.php
+++ b/core/tests/phpunit-bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-// Include Symfony autoloader
+// Include Composer autoloader
 require_once('../vendor/autoload.php');
 
 // Set timezone to avoid warnings


### PR DESCRIPTION
The unit tests still do not pass completely as they cannot connect to any
DB on Travis yet. This will be part of a separate PR.

(And unit tests should not connect to a real database.)