### PR TITLE
[TASK] Drop HHVM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
   include:
   - php: 7.0
   - php: 7.1
-  - php: hhvm
 
 before_install:
   - mysql -e 'CREATE DATABASE phplist;'


### PR DESCRIPTION
HHVM in PHP 7 mode breaks Composer, and HHVM in non-PHP-7 mode causes
composer to exit the install process due to the PHP version being too low.

Other big projects are dropping support for HHVM due to these issues, too.